### PR TITLE
Recommend PEP8 style guide first for Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ coding style guides and development practices across the web.
 
 ### Python
 
++ [PEP 8 - Style Guide for Python Code](https://www.python.org/dev/peps/pep-0008/)
 + [Google Python Style Guide](http://google-styleguide.googlecode.com/svn/trunk/pyguide.html)
 
 ### Shell


### PR DESCRIPTION
Google's style guide is a good suggestion but outside of Google it's not canonical in any way. Additionally, the Google style guide seems to be Python 2-specific.
