### PR TITLE
added Popular Guides section to Styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ coding style guides and development practices across the web.
 ## Contents
 
 + Styling
-  + [Popular Guides](#styleguides)
+  + [Popular Guides](#popular-guides)
   + [CSS](#css)
   + [Sass](#sass)
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ coding style guides and development practices across the web.
 ## Contents
 
 + Styling
+  + [Popular Guides](#styleguides)
   + [CSS](#css)
   + [Sass](#sass)
 
@@ -42,9 +43,13 @@ coding style guides and development practices across the web.
 
 ## Styling
 
-### CSS
+### Popular Guides
 
 + [Google HTML/CSS Style Guide](http://google-styleguide.googlecode.com/svn/trunk/htmlcssguide.xml)
++ [Mailchimp Pattern Library](http://ux.mailchimp.com/patterns/)
+
+### CSS
+
 + [Principles of writing consistent, idiomatic CSS](https://github.com/necolas/idiomatic-css#readme)
 + [HTML and CSS code guide](https://github.com/mdo/code-guide#readme)
 + [General CSS notes, advice and guidelines](https://github.com/csswizardry/CSS-Guidelines#readme)


### PR DESCRIPTION
I saw the google guide was in Styling > CSS already and I wanted to add Mailchimp's Pattern Library. These are both popular style guides not specific to CSS so I created the new section and placed these both in there. 
