### PR TITLE
Fixed link **Google HTML/CSS Style Guide**

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ coding style guides and development practices across the web.
 
 ### CSS
 
-+ [Google HTML/CSS Style Guide](http://google-styleguide.googlecode.com/svn/trunk/htmlcssguide.xml)
++ [Google HTML/CSS Style Guide](https://google.github.io/styleguide/htmlcssguide.xml)
 + [Principles of writing consistent, idiomatic CSS](https://github.com/necolas/idiomatic-css#readme)
 + [HTML and CSS code guide](https://github.com/mdo/code-guide#readme)
 + [General CSS notes, advice and guidelines](https://github.com/csswizardry/CSS-Guidelines#readme)


### PR DESCRIPTION
Edited the link of "Google HTML/CSS Style Guide" in CSS section which was giving 404 error
