### PR TITLE
[PHP] Use PHP-FIG as a resource for standards

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ coding style guides and development practices across the web.
 ### PHP
 
 + [PHP: The Right Way](http://www.phptherightway.com/)
-+ [PHP Coding Standards](https://github.com/maxdmyers/php-style-guide#readme)
++ [PHP Standard Recommendations](https://www.php-fig.org/psr/)
 
 ### Perl
 


### PR DESCRIPTION
PHP-FIG is a community driven group with standards recommendations such as coding style. This patch adds PHP-FIG in favor of previous recommended coding style guide.