### PR TITLE
Adding webhooks section / article

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ coding style guides and development practices across the web.
 
 + [Other](#other)
   + [API](#api)
-  + [Webhooks](#webhooks)
   + [Bots](#bots)
   + [Deployment](#deployment)
   + [Favicon](#favicon)
@@ -54,6 +53,7 @@ coding style guides and development practices across the web.
   + [Security](#security)
   + [UI](#ui)
   + [Writing](#writing)
+  + [Webhooks](#webhooks)
 
 ## Styling
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ coding style guides and development practices across the web.
 
 + [Other](#other)
   + [API](#api)
+  + [Webhooks](#webhooks)
   + [Bots](#bots)
   + [Deployment](#deployment)
   + [Favicon](#favicon)
@@ -197,6 +198,10 @@ coding style guides and development practices across the web.
 + [Principles of good RESTful API Design](https://codeplanet.io/principles-good-restful-api-design/)
 + [Microsoft REST API Guidelines](https://github.com/Microsoft/api-guidelines/blob/vNext/Guidelines.md#readme)
 + [Building JSON-LD APIs: Best Practices](https://json-ld.org/spec/latest/json-ld-api-best-practices/)
+
+### Webhooks
+
++ [Working with Webhooks](https://requestbin.com/blog/working-with-webhooks/)
 
 ### Bots
 

--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ coding style guides and development practices across the web.
   + [Node.js](#nodejs)
   + [Security](#security)
   + [UI](#ui)
-  + [Writing](#writing)
   + [Webhooks](#webhooks)
+  + [Writing](#writing)
 
 ## Styling
 
@@ -199,10 +199,6 @@ coding style guides and development practices across the web.
 + [Microsoft REST API Guidelines](https://github.com/Microsoft/api-guidelines/blob/vNext/Guidelines.md#readme)
 + [Building JSON-LD APIs: Best Practices](https://json-ld.org/spec/latest/json-ld-api-best-practices/)
 
-### Webhooks
-
-+ [Working with Webhooks](https://requestbin.com/blog/working-with-webhooks/)
-
 ### Bots
 
 + [Principles of bot design](https://docs.microsoft.com/en-us/azure/bot-service/bot-service-design-principles?view=azure-bot-service-3.0)
@@ -249,6 +245,10 @@ coding style guides and development practices across the web.
 
 + [A Good User Interface](https://goodui.org/)
 + [Pagination 101](https://gist.github.com/mislav/622561)
+
+### Webhooks
+
++ [Working with Webhooks](https://requestbin.com/blog/working-with-webhooks/)
 
 ### Writing
 


### PR DESCRIPTION
Given the volume of webhooks available these days, I thought a section on webhooks might be nice. I've linked to a guide I wrote that tries to balance introducing webhooks to beginners with technical detail.

I reviewed the contributing guidelines and believe I checked all the boxes, but please let me know if this looks OK or if I need to make any changes to this PR!