### PR TITLE
Move Rust to Languages, add Table of Contents Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ coding style guides and development practices across the web.
   + [CoffeeScript](#coffeescript)
   + [Elixir](#elixir)
   + [Go](#go)
+  + [Haskell](#haskell)
   + [JavaScript](#javascript)
   + [Java](#java)
   + [Objective-C](#objective-c)
@@ -29,6 +30,7 @@ coding style guides and development practices across the web.
   + [Perl](#perl)
   + [Python](#python)
   + [Ruby](#ruby)
+  + [Rust](#rust)
   + [Scala](#scala)
   + [Shell](#shell)
   + [SQL](#sql)
@@ -158,6 +160,10 @@ coding style guides and development practices across the web.
 + [The Ruby Style Guide](https://github.com/rubocop-hq/ruby-style-guide#readme)
 + [Ruby Style Guidelines](http://www.caliban.org/ruby/rubyguide.shtml#style)
 
+### Rust
+
++ [The Rust Style Guide](https://github.com/rust-dev-tools/fmt-rfcs/blob/master/guide/guide.md)
+
 ### Scala
 
 + [Scala Style Guide](https://docs.scala-lang.org/style/)
@@ -195,10 +201,6 @@ coding style guides and development practices across the web.
 ### Rails
 
 + [The Rails Style Guide](https://github.com/rubocop-hq/rails-style-guide#readme)
-
-### Rust
-
-+ [The Rust Style Guide](https://github.com/rust-dev-tools/fmt-rfcs/blob/master/guide/guide.md)
 
 ### Vue
 


### PR DESCRIPTION
Added a table of contents link for Haskell and Rust
Moved Rust to the Languages section instead of Frameworks